### PR TITLE
fix: Reduce homepage snap-scroll stutter on trackpad and touch

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -72,6 +72,19 @@ layout: default
       event.stopPropagation();
     })
   }
+  // Smooth-scroll for in-page anchor links (CSS scroll-behavior is off
+  // so it doesn't fight native snap during ordinary scrolling).
+  document.querySelectorAll('a.homepage-link[href^="#"]').forEach((link) => {
+    link.addEventListener("click", (event) => {
+      const targetId = link.getAttribute("href").slice(1);
+      const target = document.getElementById(targetId);
+      if (!target) return;
+      event.preventDefault();
+      target.scrollIntoView({ behavior: "smooth", block: "start" });
+      history.pushState(null, "", "#" + targetId);
+    });
+  });
+
   // Select cards
   const cards = document.querySelectorAll(".project-card")
   let i = 0;
@@ -100,7 +113,15 @@ layout: default
     document.documentElement.classList.remove("using-keyboard");
     document.documentElement.classList.add("using-mouse");
   });
+  let isScrolling = false;
+  let scrollIdleTimer = 0;
+  window.addEventListener("scroll", () => {
+    isScrolling = true;
+    clearTimeout(scrollIdleTimer);
+    scrollIdleTimer = setTimeout(() => { isScrolling = false; }, 150);
+  }, { passive: true });
   document.addEventListener("mouseover", (e) => {
+    if (isScrolling) return;
     const card = e.target.closest(".project-card");
     const usingKeyboard = document.documentElement.classList.contains("using-keyboard");
     if (!card || usingKeyboard ) return;

--- a/_sass/home.scss
+++ b/_sass/home.scss
@@ -38,9 +38,14 @@ body {
 
 html {
   scroll-snap-type: y proximity;
-  scroll-behavior: smooth;
   -webkit-overflow-scrolling: touch;
   background-color: $homepage-background-color;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-snap-type: none;
+  }
 }
 
 a {
@@ -92,17 +97,14 @@ p, ul {
 /** homepage styling */
 .homepage-card {
   color: $homepage-font-color;
-  overflow-y: auto;
-  overscroll-behavior-y: contain;
   display: flex;
   font-size: 1.3em;
   justify-content: center;
   align-items: center;
-  min-height: clamp(500px, 100vh, 100vh);
+  min-height: clamp(500px, 100svh, 100svh);
   box-sizing: border-box;
   margin-bottom: 2em;
   scroll-snap-align: start;
-  scroll-snap-stop: always;
   padding: 0 1em;
 }
 
@@ -276,7 +278,7 @@ p, ul {
   font-size: 0.9em;
   border-radius: 10px;
   padding: 20px;
-  box-shadow: 5px 5px 5px 3px rgba(1,1,1,0.3);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.35);
   box-sizing: border-box;
   z-index: 2;
 }
@@ -387,7 +389,7 @@ html.using-keyboard .project-card:focus-visible {
   margin: 10px 0px;
   border-radius: 10px;
   background-color: $project-card-color;
-  box-shadow: 5px 5px 5px 3px rgba(1,1,1,0.3);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.35);
 }
 
 .blog-post-link:hover {


### PR DESCRIPTION
## Summary
- Loosen homepage scroll-snap so trackpad and touch flicks aren't forced to stop on every section: drop `scroll-snap-stop: always`, drop `scroll-behavior: smooth` on `html` (so it doesn't fight native snap), and switch `.homepage-card` sizing from `100vh` to `100svh` so iOS URL-bar transitions don't shift the snap line mid-scroll.
- Remove the nested scroll containers on `.homepage-card` (`overflow-y: auto` + `overscroll-behavior-y: contain`) that were intercepting wheel/touch events from the outer snap container.
- Cut per-frame work during scroll: gate the document `mouseover` focus-shift behind a debounced `isScrolling` flag so cursor-over-card no longer thrashes layout while scrolling, and lighten the project-card / blog-post-link `box-shadow` to an axis-aligned, no-spread shadow that paints faster.
- Re-add smooth scroll for the in-page anchor links via a click handler so the nav links still glide. Add a `prefers-reduced-motion` rule that disables snap entirely.

## Test plan
- [ ] Trackpad: slow two-finger scroll snaps cleanly through all three sections; fast flick passes through without stuttering on every card.
- [ ] Mobile: rapid flicks while the URL bar shows/hides do not jump the snap line.
- [ ] In-page anchor links (\"View my portfolio\", \"Learn a bit more about me\") still smooth-scroll to the right card and update the URL hash.
- [ ] Project modal still opens on click and Enter, closes on Esc and outside-click.
- [ ] System Settings → Reduce Motion on: page scrolls without snap.